### PR TITLE
complete sync only on 204

### DIFF
--- a/src/main/java/com/getbase/sync/SyncProcess.java
+++ b/src/main/java/com/getbase/sync/SyncProcess.java
@@ -44,7 +44,7 @@ public class SyncProcess {
     private boolean fetchMore() {
         nextItems = this.client.sync().fetch(this.deviceUUID, session.getId());
 
-        return nextItems != null && !nextItems.isEmpty();
+        return nextItems != null;
     }
 
     // Drain the main queue until there is no more data (empty array)

--- a/src/main/java/com/getbase/sync/SyncService.java
+++ b/src/main/java/com/getbase/sync/SyncService.java
@@ -10,6 +10,7 @@ import com.getbase.services.BaseService;
 import java.util.*;
 
 import static com.getbase.utils.Precondition.*;
+import static java.util.Collections.emptyList;
 
 public class SyncService extends BaseService {
     public static final String DEVICE_HEADER = "X-Basecrm-Device-UUID";
@@ -54,9 +55,9 @@ public class SyncService extends BaseService {
 
         Map<String, Object> attributes = JsonDeserializer.deserializeRaw(response.getBody());
 
-        // sanity check
+        // make sure we only complete on 204
         if (attributes == null || attributes.get("items") == null) {
-            return null;
+            return emptyList();
         }
 
         return (List<Map<String, Object>>)attributes.get("items");


### PR DESCRIPTION
Sync process should complete only when HTTP 204 is returned. Current version of client completes sync process if returned item collection is empty even though 204 has not been returned. This is incorrect behaviour as sync is still in progress and next request can still return items. This PR delivers a fix to this.
