### PR TITLE
extract builder from jersey http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ public class InstrumentedHttpClientBuilder implements Builder {
 
 Finally you need to pass your `Builder` when constructing a `Client`.
 ```java
- final HttpClient httpClient = new HttpClient(config, new InstrumentedHttpClientBuilder(properties, filters));
+ final HttpClient httpClient = new HttpClient(config, new InstrumentedHttpClientBuilder(requestMetricsFilter));
  Client client = new Client(config, httpClient);
 ```
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Actions:
 * Retrieve an authenticating user - `client.users().self()`
 
 ## Advanced Topic - Instrumenting HTTP Client
-BASE API client uses Jersey HTTP Client that can be instrumented using [client filters mechanism](https://jersey.java.net/documentation/latest/filters-and-interceptors.html#d0e9771). This might be helpful if for example you want to publish performance metrics for every request, etc. In order to instrument a client or provide some additional configuration you need to implement `com.getbase.http.jersey.Builer` interface and pass it when constructing `com.getbase.http.jersey.HttpClient`.
+Base API client uses Jersey HTTP Client that can be instrumented using [client filters mechanism](https://jersey.java.net/documentation/latest/filters-and-interceptors.html#d0e9771). This might be helpful if for example you want to publish performance metrics for every request, etc. In order to instrument a client or provide some additional configuration you need to implement `com.getbase.http.jersey.Builer` interface and pass it when constructing `com.getbase.http.jersey.HttpClient`.
 
 Here is an example of client filter that publishes performance metrics:
 ```java

--- a/src/main/java/com/getbase/http/jersey/Builder.java
+++ b/src/main/java/com/getbase/http/jersey/Builder.java
@@ -1,0 +1,9 @@
+package com.getbase.http.jersey;
+
+import com.getbase.Configuration;
+
+import javax.ws.rs.client.Client;
+
+public interface Builder {
+    Client build(Configuration configuration);
+}


### PR DESCRIPTION
When extending com.getbase.http.hersey.HttpClient you would like to override createJerseyClient to provide your own configuration (e.g. add filters, setup some custom properties, etc). In current implementation when you extend the class you effectively cannot pass any other arguments to this method as it is called by super constructor before you can store any additional parameters. Fix for this would be to extract abstraction responsible for client configuration and build. This however breaks current API. Let me know what you think. (other option - extending Configuration - is problematic due to necessary casting in createJerseyClient and because public static final class Builder is defined in Configuration).
